### PR TITLE
Making markup the same as the markup for candidate committee charts

### DIFF
--- a/templates/partials/ie-chart.html
+++ b/templates/partials/ie-chart.html
@@ -4,10 +4,10 @@
 {% import 'macros/charts.html' as charts %}
 
 {% if series_group_has_data(reports, ('independent_contributions_period', 'independent_expenditures_period')) %}
-<div class="row">
+<div class="content__section--extra">
   <figure class="chart-container chart--r-d">
     <div class="chart__header">
-      <h4 class="chart__title"> Contributions received and independent expenditures</h4>
+      <h3 class="chart__title"> Contributions received and independent expenditures</h3>
       <ul class="chart__key list--flat">
         <li class="chart__key__item"><span class="swatch"></span> Total contributions received</li>
         <li class="chart__key__item"><span class="swatch"></span> Total independent expenditures</li>


### PR DESCRIPTION
Just noticed that the IE-charts partial never got updated markup so it was looking different than the candidate committee charts. This fixes that.
