### PR TITLE
Additional download edits

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -16,8 +16,12 @@ var download = require('./download');
 var analytics = require('./analytics');
 
 var hideNullTemplate = require('../../templates/tables/hideNull.hbs');
+var exportWidgetTemplate = require('../../templates/tables/exportWidget.hbs');
 
 var simpleDOM = 't<"results-info"ip>';
+var browseDOM = '<"js-results-info results-info results-info--top"ilfrp>' +
+                '<"panel__main"t>' +
+                '<"results-info"ip>';
 
 // Only show table after draw
 $(document.body).on('draw.dt', function() {
@@ -411,7 +415,8 @@ var defaultOpts = {
   lengthMenu: [30, 50, 100],
   responsive: {details: false},
   language: {lengthMenu: 'Results per page: _MENU_'},
-  dom: '<"js-results-info results-info results-info--top"lfrp><"panel__main"t><"results-info"ip>',
+  title: null,
+  dom: browseDOM,
 };
 
 var defaultCallbacks = {
@@ -476,9 +481,11 @@ DataTable.prototype.ensureWidgets = function() {
   }
 
   if (this.opts.useExport) {
-    this.$exportWidget = $('<div class="button button--primary-contrast results-info__download">Export this data</div>');
+    var title = this.opts.title;
+    this.$exportWidget = $(exportWidgetTemplate(title));
+    $paging.after(this.$exportWidget);
+    this.$exportButton = $('.js-export');
     this.$exportWidget.on('click', this.export.bind(this));
-    $paging.prepend(this.$exportWidget);
   }
 
   this.hasWidgets = true;
@@ -562,6 +569,7 @@ DataTable.defer = function($table, opts) {
 
 module.exports = {
   simpleDOM: simpleDOM,
+  browseDOM: browseDOM,
   yearRange: yearRange,
   getCycle: getCycle,
   buildTotalLink: buildTotalLink,

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -19,7 +19,7 @@ var hideNullTemplate = require('../../templates/tables/hideNull.hbs');
 var exportWidgetTemplate = require('../../templates/tables/exportWidget.hbs');
 
 var simpleDOM = 't<"results-info"ip>';
-var browseDOM = '<"js-results-info results-info results-info--top"ilfrp>' +
+var browseDOM = '<"js-results-info results-info results-info--top"iplfr>' +
                 '<"panel__main"t>' +
                 '<"results-info"ip>';
 
@@ -477,7 +477,7 @@ DataTable.prototype.ensureWidgets = function() {
 
   if (this.opts.useHideNull) {
     this.$hideNullWidget = $(hideNullTemplate());
-    $paging.prepend(this.$hideNullWidget);
+    $paging.append(this.$hideNullWidget);
   }
 
   if (this.opts.useExport) {

--- a/static/js/pages/candidates.js
+++ b/static/js/pages/candidates.js
@@ -49,6 +49,7 @@ $(document).ready(function() {
   var $table = $('#results');
   var filterPanel = new FilterPanel('#category-filters');
   new tables.DataTable($table, {
+    title: 'Candidate',
     path: ['candidates'],
     panel: filterPanel,
     columns: columns,

--- a/static/js/pages/committees.js
+++ b/static/js/pages/committees.js
@@ -44,6 +44,7 @@ $(document).ready(function() {
   var $table = $('#results');
   var filterPanel = new FilterPanel('#category-filters');
   new tables.DataTable($table, {
+    title: 'Committee',
     panel: filterPanel,
     path: ['committees'],
     columns: columns,

--- a/static/js/pages/disbursements.js
+++ b/static/js/pages/disbursements.js
@@ -63,6 +63,7 @@ $(document).ready(function() {
   var $table = $('#results');
   var filterPanel = new FilterPanel('#category-filters');
   new tables.DataTable($table, {
+    title: 'Disbursement',
     path: ['schedules', 'schedule_b'],
     panel: filterPanel,
     columns: columns,

--- a/static/js/pages/filings.js
+++ b/static/js/pages/filings.js
@@ -21,6 +21,7 @@ $(document).ready(function() {
   var $table = $('#results');
   var filterPanel = new FilterPanel('#category-filters');
   new tables.DataTable($table, {
+    title: 'Filing',
     path: ['filings'],
     panel: filterPanel,
     columns: filingsColumns,

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -62,6 +62,7 @@ $(document).ready(function() {
   var $table = $('#results');
   var filterPanel = new FilterPanel('#category-filters');
   new tables.DataTable($table, {
+    title: 'Receipt',
     path: ['schedules', 'schedule_a'],
     panel: filterPanel,
     columns: columns,

--- a/static/templates/tables/exportWidget.hbs
+++ b/static/templates/tables/exportWidget.hbs
@@ -1,4 +1,7 @@
 <div class="results-info results-info--simple">
   <h1 class="results-info__title">{{this}} results</h1>
-  <button type="button" class="js-export-widget button button--primary-contrast results-info__download">Export this data</button>
+  <button type="button"
+    class="js-export-widget button button--primary-contrast button--export results-info__download">
+      Export this data
+  </button>
 </div>

--- a/static/templates/tables/exportWidget.hbs
+++ b/static/templates/tables/exportWidget.hbs
@@ -1,0 +1,4 @@
+<div class="results-info results-info--simple">
+  <h1 class="results-info__title">{{this}} results</h1>
+  <button type="button" class="js-export-widget button button--primary-contrast results-info__download">Export this data</button>
+</div>

--- a/static/templates/tables/hideNull.hbs
+++ b/static/templates/tables/hideNull.hbs
@@ -1,4 +1,6 @@
-<input id="null-checkbox" type="checkbox" name="sort_hide_null" checked>
-<label for="null-checkbox" class="results-info__null">
-  Hide results with missing values when sorting
-</label>
+<div class="results-info__null">
+  <input id="null-checkbox" type="checkbox" name="sort_hide_null" checked>
+  <label for="null-checkbox">
+    Hide results with missing values when sorting
+  </label>
+</div>

--- a/templates/partials/disbursements-filter.html
+++ b/templates/partials/disbursements-filter.html
@@ -10,7 +10,7 @@ Filter disbursements
 
 {% block message %}
 <div class="message message--info message--small">
-  <p>Due to the large number of transactions, records begin in 2011.</p>
+  <span class="t-block">Due to the large number of transactions, records begin in 2011.</span>
 </div>
 {% endblock %}
 
@@ -28,6 +28,6 @@ Filter disbursements
 {{ text.field('max_amount', 'Maximum expenditure') }}
 {{ date.field('date', 'Disbursement date', dates ) }}
 <div class="message message--info message--small">
-  <p>Disbursements are reported periodically, according to the filer's reporting schedule. Disbursements are updated as they’re processed— that time can vary.</p>
+  <span class="t-block">Disbursements are reported periodically, according to the filer's reporting schedule. Disbursements are updated as they’re processed— that time can vary.</span>
 </div>
 {% endblock %}

--- a/templates/partials/receipts-filter.html
+++ b/templates/partials/receipts-filter.html
@@ -12,7 +12,7 @@ Filter receipts
 
 {% block message %}
 <div class="message message--info message--small">
-  <p>Due to the large number of transactions, records begin in 2011.</p>
+  <span class="t-block">Due to the large number of transactions, records begin in 2011.</span>
 </div>
 {% endblock %}
 
@@ -65,7 +65,7 @@ Filter receipts
 {{ text.field('max_amount', 'Maximum contribution', {'data-inputmask': '"alias": "currency", "rightAlign": false, "clearMaskOnLostFocus": true'}) }}
 {{ date.field('date', 'Receipt date', dates ) }}
 <div class="message message--info message--small">
-  <p>Receipts are reported periodically, according to the filer's reporting schedule. Receipts are updated as they’re processed— that time can vary.</p>
+  <span class="t-block">Receipts are reported periodically, according to the filer's reporting schedule. Receipts are updated as they’re processed— that time can vary.</span>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Re-arranges some of the items in the browse table headers to reflect the mockups on https://github.com/18F/openFEC-web-app/issues/946 : 

![image](https://cloud.githubusercontent.com/assets/1696495/11573624/1e4dcf6e-99bc-11e5-9197-99aff9102f7a.png)

Mainly, this adds a new template for the export widget that accepts a single title parameter in order to implement the slight change to the table headers. Browse pages set the title parameter in their table opts.
