### PR TITLE
[WIP] Export cap

### DIFF
--- a/static/js/modules/download.js
+++ b/static/js/modules/download.js
@@ -130,6 +130,12 @@ DownloadItem.prototype.refresh = function() {
   this.promise.fail(this.handleError.bind(this));
 };
 
+DownloadItem.prototype.cancel = function() {
+  var message = 'Your request contains more than 100,000 results.'
+  this.close();
+  alert(message);
+};
+
 DownloadItem.prototype.handleSuccess = function(response) {
   if (response && response.status === 'complete') {
     this.finish(response.url);
@@ -141,6 +147,8 @@ DownloadItem.prototype.handleSuccess = function(response) {
 DownloadItem.prototype.handleError = function(xhr, textStatus) {
   if (textStatus !== 'abort') {
     this.schedule();
+  } if (textStatus === '403') {
+    this.cancel();
   }
 };
 

--- a/static/js/modules/helpers.js
+++ b/static/js/modules/helpers.js
@@ -33,11 +33,17 @@ function decodeAmendment(value) {
   return decoders.amendments[value];
 }
 
+function formatNumber(value) {
+  return value.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,")
+}
+
 Handlebars.registerHelper('datetime', datetime);
 
 Handlebars.registerHelper('decodeAmendment', decodeAmendment);
 
 Handlebars.registerHelper('basePath', BASE_PATH);
+
+Handlebars.registerHelper('formatNumber', formatNumber);
 
 function cycleDates(year) {
   return {
@@ -80,6 +86,7 @@ module.exports = {
   datetime: datetime,
   ensureArray: ensureArray,
   decodeAmendment: decodeAmendment,
+  formatNumber: formatNumber,
   cycleDates: cycleDates,
   filterNull: filterNull,
   buildAppUrl: buildAppUrl,

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -23,6 +23,8 @@ var browseDOM = '<"js-results-info results-info results-info--top"iplfr>' +
                 '<"panel__main"t>' +
                 '<"results-info"ip>';
 
+var DOWNLOAD_CAP = 100000;
+
 // Only show table after draw
 $(document.body).on('draw.dt', function() {
   $('.datatable__container').css('opacity', '1');
@@ -485,11 +487,23 @@ DataTable.prototype.ensureWidgets = function() {
     this.$exportWidget = $(exportWidgetTemplate(title));
     $paging.after(this.$exportWidget);
     this.$exportButton = $('.js-export');
-    this.$exportWidget.on('click', this.export.bind(this));
+    this.$exportButton.on('click', this.export.bind(this));
   }
 
   this.hasWidgets = true;
 };
+
+DataTable.prototype.disableExport = function() {
+  this.$exportButton.addClass('disabled');
+  this.$exportButton.attr('disabled', true);
+  this.$exportButton.off('click');
+}
+
+DataTable.prototype.enableExport = function() {
+  this.$exportButton.removeClass('disabled');
+  this.$exportButton.attr('disabled', false);
+  this.$exportButton.on('click', this.export.bind(this));
+}
 
 DataTable.prototype.fetch = function(data, callback) {
   var self = this;
@@ -537,6 +551,13 @@ DataTable.prototype.fetchSuccess = function(resp) {
   this.paginator.handleResponse(this.fetchContext.data, resp);
   this.fetchContext.callback(mapResponse(resp));
   this.callbacks.afterRender(this.api, this.fetchContext.data, resp);
+
+  if (resp.pagination.count > DOWNLOAD_CAP) {
+    this.disableExport();
+  } else {
+    this.enableExport();
+  }
+
   if (this.opts.hideEmpty) {
     this.hideEmpty(resp);
   }

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -487,6 +487,7 @@ DataTable.prototype.ensureWidgets = function() {
     this.$exportWidget = $(exportWidgetTemplate(title));
     $paging.after(this.$exportWidget);
     this.$exportButton = $('.js-export');
+    this.$exportTooltipContainer = $('.js-tooltip-container');
     this.$exportButton.on('click', this.export.bind(this));
   }
 
@@ -495,14 +496,33 @@ DataTable.prototype.ensureWidgets = function() {
 
 DataTable.prototype.disableExport = function() {
   this.$exportButton.addClass('disabled');
-  this.$exportButton.attr('disabled', true);
   this.$exportButton.off('click');
+
+  // Adding everything we need for the tooltip
+  this.$exportButton.attr('aria-describedby', 'export-tooltip');
+  var $exportTooltip = this.$exportWidget.find('.tooltip');
+
+  this.$exportTooltipContainer.hover(function() {
+    $exportTooltip.attr('aria-hidden', 'false');
+  }, function() {
+    $exportTooltip.attr('aria-hidden', 'true');
+  });
+  this.$exportButton.focus(function() {
+    $exportTooltip.attr('aria-hidden', 'false');
+  });
+  this.$exportButton.blur(function() {
+    $exportTooltip.attr('aria-hidden', 'true');
+  })
 }
 
 DataTable.prototype.enableExport = function() {
   this.$exportButton.removeClass('disabled');
-  this.$exportButton.attr('disabled', false);
   this.$exportButton.on('click', this.export.bind(this));
+
+  // Remove all tooltip stuff
+  this.$exportButton.removeAttr('aria-describedby');
+  this.$exportTooltipContainer.off('mouseenter mouseleave');
+  this.$exportButton.off('focus blur');
 }
 
 DataTable.prototype.fetch = function(data, callback) {

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -486,7 +486,7 @@ DataTable.prototype.ensureWidgets = function() {
     var templateVars = {
       title: this.opts.title,
       max: DOWNLOAD_CAP
-    }
+    };
     this.$exportWidget = $(exportWidgetTemplate(templateVars));
     $paging.after(this.$exportWidget);
     this.$exportButton = $('.js-export');
@@ -516,8 +516,8 @@ DataTable.prototype.disableExport = function() {
   });
   this.$exportButton.blur(function() {
     $exportTooltip.attr('aria-hidden', 'true');
-  })
-}
+  });
+};
 
 DataTable.prototype.enableExport = function() {
   this.$exportButton.removeClass('disabled');
@@ -527,7 +527,7 @@ DataTable.prototype.enableExport = function() {
   this.$exportButton.removeAttr('aria-describedby');
   this.$exportTooltipContainer.off('mouseenter mouseleave');
   this.$exportButton.off('focus blur');
-}
+};
 
 DataTable.prototype.fetch = function(data, callback) {
   var self = this;

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -483,8 +483,11 @@ DataTable.prototype.ensureWidgets = function() {
   }
 
   if (this.opts.useExport) {
-    var title = this.opts.title;
-    this.$exportWidget = $(exportWidgetTemplate(title));
+    var templateVars = {
+      title: this.opts.title,
+      max: DOWNLOAD_CAP
+    }
+    this.$exportWidget = $(exportWidgetTemplate(templateVars));
     $paging.after(this.$exportWidget);
     this.$exportButton = $('.js-export');
     this.$exportTooltipContainer = $('.js-tooltip-container');

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -491,6 +491,7 @@ DataTable.prototype.ensureWidgets = function() {
     $paging.after(this.$exportWidget);
     this.$exportButton = $('.js-export');
     this.$exportTooltipContainer = $('.js-tooltip-container');
+    this.$exportTooltip = this.$exportWidget.find('.tooltip');
     this.$exportButton.on('click', this.export.bind(this));
   }
 
@@ -503,7 +504,7 @@ DataTable.prototype.disableExport = function() {
 
   // Adding everything we need for the tooltip
   this.$exportButton.attr('aria-describedby', 'export-tooltip');
-  var $exportTooltip = this.$exportWidget.find('.tooltip');
+  var $exportTooltip = this.$exportTooltip;
 
   this.$exportTooltipContainer.hover(function() {
     $exportTooltip.attr('aria-hidden', 'false');

--- a/static/templates/tables/exportWidget.hbs
+++ b/static/templates/tables/exportWidget.hbs
@@ -1,12 +1,12 @@
 <div class="results-info results-info--simple">
-  <h1 class="results-info__title">{{this}} results</h1>
+  <h1 class="results-info__title">{{this.title}} results</h1>
   <div class="results-info__download js-tooltip-container">
     <button type="button"
       class="js-export button button--primary-contrast button--export">
         Export this data
     </button>
     <div id="export-tooltip" role="tooltip" class="tooltip tooltip--under tooltip__content" aria-hidden="true">
-      <span>Exports are limited to 100,000 records— add filters to narrow results, or export bigger data sets with <a href="http://fec.gov/data/DataCatalog.do?cf=downloadable" target="_blank">FEC bulk data exporter</a>.</span>
+      <span>Exports are limited to {{formatNumber this.max}} records— add filters to narrow results, or export bigger data sets with <a href="http://fec.gov/data/DataCatalog.do?cf=downloadable" target="_blank">FEC bulk data exporter</a>.</span>
     </div>
   </div>
 </div>

--- a/static/templates/tables/exportWidget.hbs
+++ b/static/templates/tables/exportWidget.hbs
@@ -1,7 +1,7 @@
 <div class="results-info results-info--simple">
   <h1 class="results-info__title">{{this}} results</h1>
   <button type="button"
-    class="js-export-widget button button--primary-contrast button--export results-info__download">
+    class="js-export button button--primary-contrast button--export results-info__download">
       Export this data
   </button>
 </div>

--- a/static/templates/tables/exportWidget.hbs
+++ b/static/templates/tables/exportWidget.hbs
@@ -1,7 +1,12 @@
 <div class="results-info results-info--simple">
   <h1 class="results-info__title">{{this}} results</h1>
-  <button type="button"
-    class="js-export button button--primary-contrast button--export results-info__download">
-      Export this data
-  </button>
+  <div class="results-info__download js-tooltip-container">
+    <button type="button"
+      class="js-export button button--primary-contrast button--export">
+        Export this data
+    </button>
+    <div id="export-tooltip" role="tooltip" class="tooltip tooltip--under tooltip__content" aria-hidden="true">
+      <span>Exports are limited to 100,000 records— add filters to narrow results, or export bigger data sets with <a href="http://fec.gov/data/DataCatalog.do?cf=downloadable" target="_blank">FEC bulk data exporter</a>.</span>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Adds logic to disable the export button if the table has over 100,000 results. Hovering over or focusing on the button shows a tooltip.

If the table has under 100,000 results, it enables the button and the tooltip never shows.

![demo](http://g.recordit.co/XKlH8NfXl4.gif)

If this looks good, I can add tests. Also waiting on the final link to use for the bulk data.
