### PR TITLE
Final download tweaks

### DIFF
--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -416,7 +416,10 @@ var defaultOpts = {
   useHideNull: true,
   lengthMenu: [30, 50, 100],
   responsive: {details: false},
-  language: {lengthMenu: 'Results per page: _MENU_'},
+  language: {
+    lengthMenu: 'Results per page: _MENU_',
+    info: 'Showing _START_ – _END_ of _TOTAL_ records'
+  },
   title: null,
   dom: browseDOM,
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -19,7 +19,7 @@ var hideNullTemplate = require('../../templates/tables/hideNull.hbs');
 var exportWidgetTemplate = require('../../templates/tables/exportWidget.hbs');
 
 var simpleDOM = 't<"results-info"ip>';
-var browseDOM = '<"js-results-info results-info results-info--top"iplfr>' +
+var browseDOM = '<"js-results-info results-info results-info--top"pilfr>' +
                 '<"panel__main"t>' +
                 '<"results-info"ip>';
 

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -578,10 +578,12 @@ DataTable.prototype.fetchSuccess = function(resp) {
   this.fetchContext.callback(mapResponse(resp));
   this.callbacks.afterRender(this.api, this.fetchContext.data, resp);
 
-  if (resp.pagination.count > DOWNLOAD_CAP) {
-    this.disableExport();
-  } else {
-    this.enableExport();
+  if (this.opts.useExport) {
+    if (resp.pagination.count > DOWNLOAD_CAP) {
+      this.disableExport();
+    } else {
+      this.enableExport();
+    }
   }
 
   if (this.opts.hideEmpty) {

--- a/static/js/pages/disbursements.js
+++ b/static/js/pages/disbursements.js
@@ -71,7 +71,7 @@ $(document).ready(function() {
     order: [[3, 'desc']],
     pagingType: 'simple',
     useFilters: true,
-    useExport: true,
+    useExport: false,
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tables.modalRenderFactory(disbursementTemplate)

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -70,7 +70,7 @@ $(document).ready(function() {
     order: [[4, 'desc']],
     pagingType: 'simple',
     useFilters: true,
-    useExport: true,
+    useExport: false,
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tables.modalRenderFactory(donationTemplate)

--- a/static/templates/download/complete.hbs
+++ b/static/templates/download/complete.hbs
@@ -1,5 +1,7 @@
 <li class="download is-complete">
-  <span class="download__name">{{filename}}</span>
-  <a class="button button--primary-contrast download__button" href="{{downloadUrl}}">Download</a>
-  <button class="js-close button--cancel download__cancel"><span class="u-visually-hidden">Remove</span></button>
+  <div class="download__item">
+    <span class="download__name">{{filename}}</span>
+    <a class="button button--primary-contrast download__button" href="{{downloadUrl}}">Download</a>
+    <button class="js-close button--cancel download__cancel"><span class="u-visually-hidden">Remove</span></button>
+  </div>
 </li>

--- a/static/templates/download/pending.hbs
+++ b/static/templates/download/pending.hbs
@@ -4,5 +4,5 @@
     <span class="button button--primary-contrast download__button disabled">Download</span>
     <button class="js-close button--cancel download__cancel"><span class="u-visually-hidden">Remove</span></button>
   </div>
-  <p class="download__message">We're preparing your download. Your wait may vary depending on the number of records in your search and the amount of downloads we're currently processing.</p>
+  <p class="download__message">We're preparing your download. Your wait will vary depending on how many records you requested and how many downloads we're processing.</p>
 </li>

--- a/static/templates/download/pending.hbs
+++ b/static/templates/download/pending.hbs
@@ -1,6 +1,8 @@
 <li class="download is-pending">
-  <span class="download__name">{{filename}}</span>
-  <span class="button button--primary-contrast download__button is-disabled">Download</span>
-  <button class="js-close button--cancel download__cancel"><span class="u-visually-hidden">Remove</span></button>
-  <p class="download__message">Taking too long? Add more filters to narrow results</p>
+  <div class="download__item">
+    <span class="download__name">{{filename}}</span>
+    <span class="button button--primary-contrast download__button disabled">Download</span>
+    <button class="js-close button--cancel download__cancel"><span class="u-visually-hidden">Remove</span></button>
+  </div>
+  <p class="download__message">We're preparing your download. Your wait may vary depending on the number of records in your search and the amount of downloads we're currently processing.</p>
 </li>


### PR DESCRIPTION
- Disables exports for receipts and disbursements
- Re-arranges and edits the language of the datatables DOM based on small suggestions from usability testing
- Tweaks the markup of the download partials to get better spacing
- Adds a new message explaining pending downloads. @emileighoutlaw I took a stab at new content that would both not give the misleading instructions that adding more filters will lead to a faster download (because it won't allow you to jump your place in the queue) and to further explain the things that might determine how long you wait. Suggest your edits here and then we can make that change before merging. Suggested text:

> We're preparing your download. Your wait may vary depending on the number of records in your search and the amount of downloads we're currently processing.

Depends on https://github.com/18F/fec-style/pull/206
