### PR TITLE
Adding committee cycle range to candidate page

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -379,6 +379,12 @@ def fmt_year_range(year):
 def fmt_state_full(value):
     return constants.states[value.upper()]
 
+@app.template_filter()
+def fmt_cycle_min_max(cycles):
+    if len(cycles) > 1:
+        return '{}–{}'.format(min(cycles), max(cycles))
+    return cycles[0]
+
 # If HTTPS is on, apply full HSTS as well, to all subdomains.
 # Only use when you're sure. 31536000 = 1 year.
 if config.force_https:

--- a/templates/partials/candidate/financial-summary.html
+++ b/templates/partials/candidate/financial-summary.html
@@ -44,7 +44,7 @@
     </figure>
     <div class="candidate__committees">
       <h3 class="t-ruled--bottom">Campaign committees</h3>
-      {% for committee in committee_groups['P'] %}
+      {% for committee in committee_groups['P'] | reverse %}
       <div class="callout callout--primary">
         <div class="callout__content">
           <h4 class="callout__title">
@@ -63,7 +63,7 @@
       </div>
       {% endfor %}
       {% if committee_groups['A'] | length > 0 %}
-        {% for committee in committee_groups['A'] %}
+        {% for committee in committee_groups['A'] | reverse %}
         <div class="callout callout--neutral">
           <div class="callout__content">
             <h4 class="callout__title">

--- a/templates/partials/candidate/financial-summary.html
+++ b/templates/partials/candidate/financial-summary.html
@@ -51,6 +51,7 @@
             <a href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=cycle) }}">{{ committee.name }}</a>
           </h4>
           <span class="callout__subtitle term" data-term="principal campaign committee">Principal campaign committee</span>
+          <span class="callout__subtitle t-block">{{ committee.cycles | fmt_cycle_min_max }}</span>
         </div>
         <div class="callout__action">
           <ul class="callout__sublinks">
@@ -69,6 +70,7 @@
               <a href="{{ url_for('committee_page', c_id=committee.committee_id, cycle=cycle) }}">{{ committee.name }}</a>
             </h4>
             <span class="callout__subtitle term" data-term="authorized committee">Authorized campaign committee</span>
+            <span class="callout__subtitle t-block">{{ committee.cycles | fmt_cycle_min_max }}</span>
           </div>
           <div class="callout__action">
             <ul class="callout__sublinks">


### PR DESCRIPTION
- Adds a new template filter for showing the min and max years in a
  cycles list
- Adds it to the principal and authorized committees callouts on
  candidate pages
