### PR TITLE
Adding export tooltips

### DIFF
--- a/static/js/modules/download.js
+++ b/static/js/modules/download.js
@@ -176,10 +176,12 @@ function DownloadContainer(parent) {
 
 DownloadContainer.prototype.add = function() {
   this.items++;
+  this.$body.trigger($.Event('download:change', {downloadCount: this.items}));
 };
 
 DownloadContainer.prototype.subtract = function() {
   this.items = this.items - 1;
+  this.$body.trigger($.Event('download:change', {downloadCount: this.items}));
   if (this.items === 0) {
     this.destroy();
   }
@@ -200,5 +202,6 @@ module.exports = {
   hydrate: hydrate,
   download: download,
   DownloadItem: DownloadItem,
-  DownloadContainer: DownloadContainer
+  DownloadContainer: DownloadContainer,
+  MAX_DOWNLOADS: MAX_DOWNLOADS
 };

--- a/static/js/modules/tables.js
+++ b/static/js/modules/tables.js
@@ -510,7 +510,7 @@ DataTable.prototype.ensureWidgets = function() {
   }
 
   if(this.opts.disableExport) {
-    this.disableExport({message: EXPORTS_DISABLED})
+    this.disableExport({message: EXPORTS_DISABLED});
   }
 
   this.hasWidgets = true;

--- a/static/js/pages/disbursements.js
+++ b/static/js/pages/disbursements.js
@@ -72,7 +72,8 @@ $(document).ready(function() {
     order: [[3, 'desc']],
     pagingType: 'simple',
     useFilters: true,
-    useExport: false,
+    useExport: true,
+    disableExport: true,
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tables.modalRenderFactory(disbursementTemplate)

--- a/static/js/pages/receipts.js
+++ b/static/js/pages/receipts.js
@@ -69,7 +69,8 @@ $(document).ready(function() {
     order: [[4, 'desc']],
     pagingType: 'simple',
     useFilters: true,
-    useExport: false,
+    useExport: true,
+    disableExport: true,
     rowCallback: tables.modalRenderRow,
     callbacks: {
       afterRender: tables.modalRenderFactory(donationTemplate)

--- a/static/templates/tables/exportWidget.hbs
+++ b/static/templates/tables/exportWidget.hbs
@@ -6,10 +6,6 @@
         Export this data
     </button>
     <div id="export-tooltip" role="tooltip" class="tooltip tooltip--under tooltip__content" aria-hidden="true">
-      <span>
-        Exports are limited to {{formatNumber this.max}} records—add filters to narrow results, or export bigger
-        data sets with <a href="http://www.fec.gov/data/DataCatalog.do?cf=downloadable" target="_blank">FEC bulk data exporter</a>.
-      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- Adds event emitters / listeners when the download count is changed
  and then disables / enables the export button
- Makes it possible to pass in separate tooltip messages to the export
  button when disablExports() is called
- Sets `useExport: true` to receipts and disbursements, but disables
  them (and shows a tooltip) with `disableExport: true`… maybe there’s a
  better way to name these
